### PR TITLE
Add rejected message

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -13,5 +13,10 @@ test "" = "$(head -1 "$1" | grep -vE '^([A-Z]+\-[0-9]+:|NOJIRA:|HOTFIX:|Merge br
   echo >&2 'Aborting due to invalid commit message.'
   echo >&2 '--> Commit message needs to be prefixed by JIRA number.'
   echo >&2 '    e.g. "PBCD-345: blah" or "NOJIRA: blah" or "HOTFIX: blah"'
+  echo >&2 '--> Rejected commit message is...'
+  cat $1 | while read line; do
+    [ `expr "$line" : "^#"` -gt 0 ] && break
+    echo $line
+  done
   exit 1
 }


### PR DESCRIPTION
頑張って書いたcommit messageがNOJIRAとかを入れ忘れてrejectされて消えてしまって悲しかったので、
もとのcommit messageを表示するようにしました。

```
Aborting due to invalid commit message.
--> Commit message needs to be prefixed by JIRA number.
    e.g. "PBCD-345: blah" or "NOJIRA: blah" or "HOTFIX: blah"
--> Rejected commit message is...
Foo

Bar
Baz
```
