### PR TITLE
Fix $CURRENT_BRANCH

### DIFF
--- a/pre-push
+++ b/pre-push
@@ -3,7 +3,7 @@
 # Branch names to protect
 PROTECTED_BRANCHES=( protect-from-force-push-test master deployment/qa deployment/production deployment/demo )
 
-CURRENT_BRANCH=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
 
 PUSH_COMMAND=$(ps -ocommand= -p $PPID)
 

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -12,7 +12,7 @@ then
  exit
 fi
 
-BRANCH_NAME=`git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3`
+BRANCH_NAME=`git symbolic-ref --short HEAD`
 ISSUE_NAME=`echo $BRANCH_NAME | grep -o "${ISSUE_PREFIX}[0-9]*"`
 
 if [[ x$ISSUE_NAME != x ]]


### PR DESCRIPTION
`git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,'` だと `rails4/master` branchが `master` として扱われ、 `git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3` だと `rails4/master` branchが `rails4` として扱われました.
